### PR TITLE
Teslapowerwall - Addition of "Grid Services" status

### DIFF
--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallBindingConstants.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallBindingConstants.java
@@ -34,7 +34,6 @@ public class TeslaPowerwallBindingConstants {
 
     // List of all Channel ids
     public static final String CHANNEL_TESLAPOWERWALL_GRIDSTATUS = "gridstatus";
-    public static final String CHANNEL_TESLAPOWERWALL_GRIDCONNECTED = "gridconnected";
     public static final String CHANNEL_TESLAPOWERWALL_GRIDSERVICES = "gridservices";
     public static final String CHANNEL_TESLAPOWERWALL_BATTERYSOE = "batterysoe";
     public static final String CHANNEL_TESLAPOWERWALL_MODE = "mode";
@@ -43,7 +42,6 @@ public class TeslaPowerwallBindingConstants {
     public static final String CHANNEL_TESLAPOWERWALL_GRID_ENERGYEXPORTED = "grid_energyexported";
     public static final String CHANNEL_TESLAPOWERWALL_GRID_ENERGYIMPORTED = "grid_energyimported";
     public static final String CHANNEL_TESLAPOWERWALL_BATTERY_INSTPOWER = "battery_instpower";
-    public static final String CHANNEL_TESLAPOWERWALL_BATTERY_FREQUENCY = "battery_frequency";
     public static final String CHANNEL_TESLAPOWERWALL_BATTERY_ENERGYIMPORTED = "battery_energyimported";
     public static final String CHANNEL_TESLAPOWERWALL_BATTERY_ENERGYEXPORTED = "battery_energyexported";
     public static final String CHANNEL_TESLAPOWERWALL_HOME_INSTPOWER = "home_instpower";

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallBindingConstants.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallBindingConstants.java
@@ -34,7 +34,7 @@ public class TeslaPowerwallBindingConstants {
 
     // List of all Channel ids
     public static final String CHANNEL_TESLAPOWERWALL_GRIDSTATUS = "gridstatus";
-    public static final String CHANNEL_TESLAPOWERWALL_GRIDSERVICESACTIVE = "gridservicesactive";
+    public static final String CHANNEL_TESLAPOWERWALL_GRIDSERVICES = "gridservices";
     public static final String CHANNEL_TESLAPOWERWALL_BATTERYSOE = "batterysoe";
     public static final String CHANNEL_TESLAPOWERWALL_MODE = "mode";
     public static final String CHANNEL_TESLAPOWERWALL_RESERVE = "reserve";

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallBindingConstants.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallBindingConstants.java
@@ -34,6 +34,7 @@ public class TeslaPowerwallBindingConstants {
 
     // List of all Channel ids
     public static final String CHANNEL_TESLAPOWERWALL_GRIDSTATUS = "gridstatus";
+    public static final String CHANNEL_TESLAPOWERWALL_GRIDCONNECTED = "gridconnected";
     public static final String CHANNEL_TESLAPOWERWALL_GRIDSERVICES = "gridservices";
     public static final String CHANNEL_TESLAPOWERWALL_BATTERYSOE = "batterysoe";
     public static final String CHANNEL_TESLAPOWERWALL_MODE = "mode";
@@ -42,6 +43,7 @@ public class TeslaPowerwallBindingConstants {
     public static final String CHANNEL_TESLAPOWERWALL_GRID_ENERGYEXPORTED = "grid_energyexported";
     public static final String CHANNEL_TESLAPOWERWALL_GRID_ENERGYIMPORTED = "grid_energyimported";
     public static final String CHANNEL_TESLAPOWERWALL_BATTERY_INSTPOWER = "battery_instpower";
+    public static final String CHANNEL_TESLAPOWERWALL_BATTERY_FREQUENCY = "battery_frequency";
     public static final String CHANNEL_TESLAPOWERWALL_BATTERY_ENERGYIMPORTED = "battery_energyimported";
     public static final String CHANNEL_TESLAPOWERWALL_BATTERY_ENERGYEXPORTED = "battery_energyexported";
     public static final String CHANNEL_TESLAPOWERWALL_HOME_INSTPOWER = "home_instpower";

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallBindingConstants.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallBindingConstants.java
@@ -34,6 +34,7 @@ public class TeslaPowerwallBindingConstants {
 
     // List of all Channel ids
     public static final String CHANNEL_TESLAPOWERWALL_GRIDSTATUS = "gridstatus";
+    public static final String CHANNEL_TESLAPOWERWALL_GRIDSERVICESACTIVE = "gridservicesactive";
     public static final String CHANNEL_TESLAPOWERWALL_BATTERYSOE = "batterysoe";
     public static final String CHANNEL_TESLAPOWERWALL_MODE = "mode";
     public static final String CHANNEL_TESLAPOWERWALL_RESERVE = "reserve";

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallHandler.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallHandler.java
@@ -23,6 +23,7 @@ import org.openhab.binding.teslapowerwall.internal.api.BatterySOE;
 import org.openhab.binding.teslapowerwall.internal.api.GridStatus;
 import org.openhab.binding.teslapowerwall.internal.api.MeterAggregates;
 import org.openhab.binding.teslapowerwall.internal.api.Operations;
+import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.library.unit.MetricPrefix;
@@ -135,6 +136,13 @@ public class TeslaPowerwallHandler extends BaseThingHandler {
             if (gridStatus != null) {
                 updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRIDSTATUS,
                         new StringType(gridStatus.grid_status));
+                if (gridStatus.grid_servicesactive == "true") {
+                    updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRIDSERVICESACTIVE, OnOffType.ON);
+                } else {
+                    updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRIDSERVICESACTIVE,
+                            OnOffType.OFF);
+                }
+
             }
             if (meterAggregates != null) {
                 updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRID_INSTPOWER,

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallHandler.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallHandler.java
@@ -138,8 +138,6 @@ public class TeslaPowerwallHandler extends BaseThingHandler {
                         new StringType(gridStatus.grid_status));
                 updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRIDSERVICES,
                         (gridStatus.grid_services ? OnOffType.ON : OnOffType.OFF));
-                updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRIDCONNECTED,
-                        (gridStatus.grid_connected ? OnOffType.ON : OnOffType.OFF));
 
             }
             if (meterAggregates != null) {
@@ -151,8 +149,6 @@ public class TeslaPowerwallHandler extends BaseThingHandler {
                         new QuantityType<>(meterAggregates.grid_energyimported, Units.KILOWATT_HOUR));
                 updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_INSTPOWER,
                         new QuantityType<>(meterAggregates.battery_instpower, MetricPrefix.KILO(Units.WATT)));
-                updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_FREQUENCY,
-                        new QuantityType<>(meterAggregates.battery_frequency, Units.HERTZ));
                 updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_ENERGYEXPORTED,
                         new QuantityType<>(meterAggregates.battery_energyexported, Units.KILOWATT_HOUR));
                 updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_ENERGYIMPORTED,

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallHandler.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallHandler.java
@@ -138,6 +138,8 @@ public class TeslaPowerwallHandler extends BaseThingHandler {
                         new StringType(gridStatus.grid_status));
                 updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRIDSERVICES,
                         (gridStatus.grid_services ? OnOffType.ON : OnOffType.OFF));
+                updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRIDCONNECTED,
+                        (gridStatus.grid_connected ? OnOffType.ON : OnOffType.OFF));
 
             }
             if (meterAggregates != null) {
@@ -149,6 +151,8 @@ public class TeslaPowerwallHandler extends BaseThingHandler {
                         new QuantityType<>(meterAggregates.grid_energyimported, Units.KILOWATT_HOUR));
                 updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_INSTPOWER,
                         new QuantityType<>(meterAggregates.battery_instpower, MetricPrefix.KILO(Units.WATT)));
+                updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_FREQUENCY,
+                        new QuantityType<>(meterAggregates.battery_frequency, Units.HERTZ));
                 updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_ENERGYEXPORTED,
                         new QuantityType<>(meterAggregates.battery_energyexported, Units.KILOWATT_HOUR));
                 updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_BATTERY_ENERGYIMPORTED,

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallHandler.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/TeslaPowerwallHandler.java
@@ -114,7 +114,7 @@ public class TeslaPowerwallHandler extends BaseThingHandler {
     private void pollStatus() throws IOException {
 
         TeslaPowerwallConfiguration config = getConfigAs(TeslaPowerwallConfiguration.class);
-        if (config.email != null) {
+        if (config.email != null && config.password != null) {
             String token = webTargets.getToken(config.email, config.password);
             Operations operations = webTargets.getOperations(token);
             if (operations != null) {
@@ -136,12 +136,8 @@ public class TeslaPowerwallHandler extends BaseThingHandler {
             if (gridStatus != null) {
                 updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRIDSTATUS,
                         new StringType(gridStatus.grid_status));
-                if (gridStatus.grid_servicesactive == "true") {
-                    updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRIDSERVICESACTIVE, OnOffType.ON);
-                } else {
-                    updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRIDSERVICESACTIVE,
-                            OnOffType.OFF);
-                }
+                updateState(TeslaPowerwallBindingConstants.CHANNEL_TESLAPOWERWALL_GRIDSERVICES,
+                        (gridStatus.grid_services ? OnOffType.ON : OnOffType.OFF));
 
             }
             if (meterAggregates != null) {
@@ -171,6 +167,9 @@ public class TeslaPowerwallHandler extends BaseThingHandler {
                         new QuantityType<>(meterAggregates.solar_energyimported, Units.KILOWATT_HOUR));
             }
 
+        } else {// include log message for pre-existing installations
+            logger.info(
+                    "Local powerwall login e-mail and password are now required for proper operations. Please update configuration.");
         }
     }
 }

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/GridStatus.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/GridStatus.java
@@ -28,7 +28,7 @@ public class GridStatus {
     private static Logger LOGGER = LoggerFactory.getLogger(GridStatus.class);
 
     public String grid_status;
-    public String grid_servicesactive;
+    public Boolean grid_services;
 
     private GridStatus() {
     }
@@ -39,7 +39,7 @@ public class GridStatus {
         JsonObject jsonObject = new JsonParser().parse(response).getAsJsonObject();
         GridStatus info = new GridStatus();
         info.grid_status = jsonObject.get("grid_status").getAsString();
-        info.grid_servicesactive = jsonObject.get("grid_services_active").getAsString();
+        info.grid_services = jsonObject.get("grid_services_active").getAsString().equalsIgnoreCase("true");
         return info;
     }
 }

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/GridStatus.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/GridStatus.java
@@ -29,7 +29,6 @@ public class GridStatus {
 
     public String grid_status;
     public Boolean grid_services;
-    public Boolean grid_connected;
 
     private GridStatus() {
     }
@@ -41,7 +40,6 @@ public class GridStatus {
         GridStatus info = new GridStatus();
         info.grid_status = jsonObject.get("grid_status").getAsString();
         info.grid_services = jsonObject.get("grid_services_active").getAsString().equalsIgnoreCase("true");
-        info.grid_connected = jsonObject.get("grid_status").getAsString().equalsIgnoreCase("SystemGridConnected");
         return info;
     }
 }

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/GridStatus.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/GridStatus.java
@@ -28,6 +28,7 @@ public class GridStatus {
     private static Logger LOGGER = LoggerFactory.getLogger(GridStatus.class);
 
     public String grid_status;
+    public String grid_servicesactive;
 
     private GridStatus() {
     }
@@ -38,6 +39,7 @@ public class GridStatus {
         JsonObject jsonObject = new JsonParser().parse(response).getAsJsonObject();
         GridStatus info = new GridStatus();
         info.grid_status = jsonObject.get("grid_status").getAsString();
+        info.grid_servicesactive = jsonObject.get("grid_services_active").getAsString();
         return info;
     }
 }

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/GridStatus.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/GridStatus.java
@@ -29,6 +29,7 @@ public class GridStatus {
 
     public String grid_status;
     public Boolean grid_services;
+    public Boolean grid_connected;
 
     private GridStatus() {
     }
@@ -40,6 +41,7 @@ public class GridStatus {
         GridStatus info = new GridStatus();
         info.grid_status = jsonObject.get("grid_status").getAsString();
         info.grid_services = jsonObject.get("grid_services_active").getAsString().equalsIgnoreCase("true");
+        info.grid_connected = jsonObject.get("grid_status").getAsString().equalsIgnoreCase("SystemGridConnected");
         return info;
     }
 }

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/MeterAggregates.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/MeterAggregates.java
@@ -29,7 +29,6 @@ public class MeterAggregates {
 
     public double grid_instpower;
     public double battery_instpower;
-    public double battery_frequency;
     public double home_instpower;
     public double solar_instpower;
     public double grid_energyexported;
@@ -57,7 +56,6 @@ public class MeterAggregates {
 
         JsonObject batteryjson = jsonObject.get("battery").getAsJsonObject();
         info.battery_instpower = batteryjson.get("instant_power").getAsDouble() / 1000;
-        info.battery_frequency = batteryjson.get("frequency").getAsDouble();
         info.battery_energyexported = batteryjson.get("energy_exported").getAsDouble() / 1000;
         info.battery_energyimported = batteryjson.get("energy_imported").getAsDouble() / 1000;
 

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/MeterAggregates.java
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/java/org/openhab/binding/teslapowerwall/internal/api/MeterAggregates.java
@@ -29,6 +29,7 @@ public class MeterAggregates {
 
     public double grid_instpower;
     public double battery_instpower;
+    public double battery_frequency;
     public double home_instpower;
     public double solar_instpower;
     public double grid_energyexported;
@@ -56,6 +57,7 @@ public class MeterAggregates {
 
         JsonObject batteryjson = jsonObject.get("battery").getAsJsonObject();
         info.battery_instpower = batteryjson.get("instant_power").getAsDouble() / 1000;
+        info.battery_frequency = batteryjson.get("frequency").getAsDouble();
         info.battery_energyexported = batteryjson.get("energy_exported").getAsDouble() / 1000;
         info.battery_energyimported = batteryjson.get("energy_imported").getAsDouble() / 1000;
 

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/resources/OH-INF/thing/thing-types.xml
@@ -10,6 +10,7 @@
 
 		<channels>
 			<channel id="gridstatus" typeId="teslapowerwall-gridstatus"/>
+			<channel id="gridservicesactive" typeId="teslapowerwall-gridservicesactive"/>
 			<channel id="batterysoe" typeId="teslapowerwall-batterysoe"/>
 			<channel id="mode" typeId="teslapowerwall-mode"/>
 			<channel id="reserve" typeId="teslapowerwall-reserve"/>
@@ -54,6 +55,12 @@
 		<item-type>String</item-type>
 		<label>Grid Status</label>
 		<description>Current status of the Power Grid</description>
+		<state readOnly="true"/>
+	</channel-type>
+	<channel-type id="teslapowerwall-gridservicesactive">
+		<item-type>Switch</item-type>
+		<label>Grid Services Active</label>
+		<description>Grid Services Activation Status</description>
 		<state readOnly="true"/>
 	</channel-type>
 	<channel-type id="teslapowerwall-batterysoe">

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/resources/OH-INF/thing/thing-types.xml
@@ -10,7 +10,7 @@
 
 		<channels>
 			<channel id="gridstatus" typeId="teslapowerwall-gridstatus"/>
-			<channel id="gridservicesactive" typeId="teslapowerwall-gridservicesactive"/>
+			<channel id="gridservices" typeId="teslapowerwall-gridservices"/>
 			<channel id="batterysoe" typeId="teslapowerwall-batterysoe"/>
 			<channel id="mode" typeId="teslapowerwall-mode"/>
 			<channel id="reserve" typeId="teslapowerwall-reserve"/>
@@ -57,9 +57,9 @@
 		<description>Current status of the Power Grid</description>
 		<state readOnly="true"/>
 	</channel-type>
-	<channel-type id="teslapowerwall-gridservicesactive">
+	<channel-type id="teslapowerwall-gridservices">
 		<item-type>Switch</item-type>
-		<label>Grid Services Active</label>
+		<label>Grid Services</label>
 		<description>Grid Services Activation Status</description>
 		<state readOnly="true"/>
 	</channel-type>

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/resources/OH-INF/thing/thing-types.xml
@@ -10,12 +10,14 @@
 
 		<channels>
 			<channel id="gridstatus" typeId="teslapowerwall-gridstatus"/>
+			<channel id="gridconnected" typeId="teslapowerwall-gridconnected"/>
 			<channel id="gridservices" typeId="teslapowerwall-gridservices"/>
 			<channel id="batterysoe" typeId="teslapowerwall-batterysoe"/>
 			<channel id="mode" typeId="teslapowerwall-mode"/>
 			<channel id="reserve" typeId="teslapowerwall-reserve"/>
 			<channel id="grid_instpower" typeId="teslapowerwall-grid_instpower"/>
 			<channel id="battery_instpower" typeId="teslapowerwall-battery_instpower"/>
+			<channel id="battery_frequency" typeId="teslapowerwall-battery_frequency"/>
 			<channel id="home_instpower" typeId="teslapowerwall-home_instpower"/>
 			<channel id="solar_instpower" typeId="teslapowerwall-solar_instpower"/>
 			<channel id="grid_energyexported" typeId="teslapowerwall-grid_energyexported"/>
@@ -50,7 +52,12 @@
 		</config-description>
 
 	</thing-type>
-
+	<channel-type id="teslapowerwall-gridconnected">
+		<item-type>Switch</item-type>
+		<label>Grid Connected</label>
+		<description>Grid Connected status</description>
+		<state readOnly="true"/>
+	</channel-type>
 	<channel-type id="teslapowerwall-gridstatus">
 		<item-type>String</item-type>
 		<label>Grid Status</label>
@@ -91,6 +98,12 @@
 		<label>Instanteous Battery Power</label>
 		<description>Instantaneous Battery Power Supply</description>
 		<state readOnly="true" pattern="%.1f %unit%"/>
+	</channel-type>
+	<channel-type id="teslapowerwall-battery_frequency">
+		<item-type>Number:Frequency</item-type>
+		<label>Battery Frequency</label>
+		<description>Battery Frequency</description>
+		<state readOnly="true" pattern="%.2f %unit%"/>
 	</channel-type>
 	<channel-type id="teslapowerwall-home_instpower">
 		<item-type>Number:Power</item-type>

--- a/bundles/org.openhab.binding.teslapowerwall/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.teslapowerwall/src/main/resources/OH-INF/thing/thing-types.xml
@@ -10,14 +10,12 @@
 
 		<channels>
 			<channel id="gridstatus" typeId="teslapowerwall-gridstatus"/>
-			<channel id="gridconnected" typeId="teslapowerwall-gridconnected"/>
 			<channel id="gridservices" typeId="teslapowerwall-gridservices"/>
 			<channel id="batterysoe" typeId="teslapowerwall-batterysoe"/>
 			<channel id="mode" typeId="teslapowerwall-mode"/>
 			<channel id="reserve" typeId="teslapowerwall-reserve"/>
 			<channel id="grid_instpower" typeId="teslapowerwall-grid_instpower"/>
 			<channel id="battery_instpower" typeId="teslapowerwall-battery_instpower"/>
-			<channel id="battery_frequency" typeId="teslapowerwall-battery_frequency"/>
 			<channel id="home_instpower" typeId="teslapowerwall-home_instpower"/>
 			<channel id="solar_instpower" typeId="teslapowerwall-solar_instpower"/>
 			<channel id="grid_energyexported" typeId="teslapowerwall-grid_energyexported"/>
@@ -52,12 +50,7 @@
 		</config-description>
 
 	</thing-type>
-	<channel-type id="teslapowerwall-gridconnected">
-		<item-type>Switch</item-type>
-		<label>Grid Connected</label>
-		<description>Grid Connected status</description>
-		<state readOnly="true"/>
-	</channel-type>
+
 	<channel-type id="teslapowerwall-gridstatus">
 		<item-type>String</item-type>
 		<label>Grid Status</label>
@@ -98,12 +91,6 @@
 		<label>Instanteous Battery Power</label>
 		<description>Instantaneous Battery Power Supply</description>
 		<state readOnly="true" pattern="%.1f %unit%"/>
-	</channel-type>
-	<channel-type id="teslapowerwall-battery_frequency">
-		<item-type>Number:Frequency</item-type>
-		<label>Battery Frequency</label>
-		<description>Battery Frequency</description>
-		<state readOnly="true" pattern="%.2f %unit%"/>
 	</channel-type>
 	<channel-type id="teslapowerwall-home_instpower">
 		<item-type>Number:Power</item-type>


### PR DESCRIPTION
Added a channel to reflect activation of grid services. Also added logger message for pre-existing thing installations that may have blank username and password.