### PR TITLE
[roborock] URL encode email and password

### DIFF
--- a/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockWebTargets.java
+++ b/bundles/org.openhab.binding.roborock/src/main/java/org/openhab/binding/roborock/internal/RoborockWebTargets.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.roborock.internal;
 
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
@@ -104,7 +105,8 @@ public class RoborockWebTargets {
     @Nullable
     public Login doLogin(String email, String password)
             throws RoborockCommunicationException, RoborockAuthenticationException, NoSuchAlgorithmException {
-        String payload = "?username=" + email + "&password=" + password + "&needtwostepauth=false";
+        String payload = "?username=" + URLEncoder.encode(email, StandardCharsets.UTF_8) + "&password="
+                + URLEncoder.encode(password, StandardCharsets.UTF_8) + "&needtwostepauth=false";
         safeToken = generateSafeToken(email);
         String response = invoke(getTokenUri + payload, HttpMethod.POST, null, null, null);
         return gson.fromJson(response, Login.class);


### PR DESCRIPTION
I am looking forward to a working version of this new plugin - thanks for your work!

While testing I found that the password and email has to be url encoded. Especially the password may contain characters that are not valid. With this change, I could add a **Roborock Account Handler** and then scan for my roborock.

Furthermore, I had to change https://usiot.roborock.com to https://euiot.roborock.com in the code. Otherwise the roborock thing did not came online. Probably the same logic as in https://github.com/Python-roborock/python-roborock/blob/0a63addeeaf918df4aa83b03a052ea05be370645/roborock/web_api.py#L59 is required such that the binding works everywhere around the world.